### PR TITLE
fix: Correct Docker Compose command syntax in start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -11,7 +11,8 @@ then
 fi
 
 # Build and start the services in detached mode
-docker compose up
+docker-compose up
+
 
 # Follow logs of the main app service (optional)
 echo "📜 Attaching to app logs..."


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrects Docker Compose command syntax from `docker compose` to `docker-compose`

- Ensures consistency with the installation command that installs `docker-compose` package


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["start.sh"] -- "Update command syntax" --> B["docker-compose up"]
  B -- "Matches installed package" --> C["docker-compose"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>start.sh</strong><dd><code>Correct Docker Compose command syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

start.sh

<ul><li>Changed <code>docker compose up</code> to <code>docker-compose up</code> for consistency<br> <li> Aligns with the <code>docker-compose</code> package installed via apt-get<br> <li> Ensures the script uses the correct command format for the installed <br>tool</ul>


</details>


  </td>
  <td><a href="https://github.com/zyx-0314/Demo-Sunset-Funeral-Homes/pull/52/files#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

